### PR TITLE
shared:network: bootstrap ktor tcp server

### DIFF
--- a/shared/network/build.gradle.kts
+++ b/shared/network/build.gradle.kts
@@ -4,5 +4,10 @@ plugins {
 }
 
 dependencies {
-    // Keep this lightweight; add Netty/Ktor later when needed.
+    implementation(libs.kotlinxCoroutines)
+    implementation(libs.ktor.network)
+
+    testImplementation(libs.bundles.test)
+    testImplementation(libs.kotlinxCoroutines)
+    testImplementation(libs.ktor.network)
 }

--- a/shared/network/src/main/kotlin/com/tkblackbelt/conquer4k/shared/network/KtorNetworkServer.kt
+++ b/shared/network/src/main/kotlin/com/tkblackbelt/conquer4k/shared/network/KtorNetworkServer.kt
@@ -1,0 +1,62 @@
+package com.tkblackbelt.conquer4k.shared.network
+
+import io.ktor.network.selector.SelectorManager
+import io.ktor.network.sockets.ServerSocket
+import io.ktor.network.sockets.Socket
+import io.ktor.network.sockets.aSocket
+import io.ktor.network.util.DefaultByteBufferPool
+import io.ktor.utils.io.pool.ObjectPool
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import java.net.InetSocketAddress
+import java.nio.ByteBuffer
+
+/**
+ * Ktor-based [NetworkServer] implementation using a [ByteBuffer] pool.
+ * It accepts TCP connections and delegates handling to the provided [TcpSessionHandler].
+ */
+class KtorNetworkServer(
+    private val config: ServerConfig,
+    private val handler: TcpSessionHandler,
+    private val pool: ObjectPool<ByteBuffer> = DefaultByteBufferPool,
+) : NetworkServer {
+    private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+    private val selector = SelectorManager(Dispatchers.IO)
+    private var serverSocket: ServerSocket? = null
+
+    /** The actual port the server is bound to. */
+    val port: Int
+        get() = (serverSocket?.localAddress as? InetSocketAddress)?.port ?: config.port
+
+    override fun start() {
+        serverSocket = runBlocking { aSocket(selector).tcp().bind(config.host, config.port) }
+        scope.launch {
+            val server = serverSocket ?: return@launch
+            while (true) {
+                val socket = server.accept()
+                launch { handler.handle(socket, pool) }
+            }
+        }
+    }
+
+    override fun stop() {
+        scope.cancel()
+        serverSocket?.close()
+        selector.close()
+    }
+}
+
+/**
+ * Functional interface for handling an individual TCP connection.
+ * Implementations are responsible for borrowing and recycling buffers from [pool].
+ */
+fun interface TcpSessionHandler {
+    suspend fun handle(
+        socket: Socket,
+        pool: ObjectPool<ByteBuffer>,
+    )
+}

--- a/shared/network/src/test/kotlin/com/tkblackbelt/conquer4k/shared/network/KtorNetworkServerTest.kt
+++ b/shared/network/src/test/kotlin/com/tkblackbelt/conquer4k/shared/network/KtorNetworkServerTest.kt
@@ -1,0 +1,94 @@
+package com.tkblackbelt.conquer4k.shared.network
+
+import io.ktor.network.selector.SelectorManager
+import io.ktor.network.sockets.aSocket
+import io.ktor.network.sockets.openReadChannel
+import io.ktor.network.sockets.openWriteChannel
+import io.ktor.network.util.DefaultByteBufferPool
+import io.ktor.utils.io.close
+import io.ktor.utils.io.core.readBytes
+import io.ktor.utils.io.pool.ObjectPool
+import io.ktor.utils.io.readAvailable
+import io.ktor.utils.io.readRemaining
+import io.ktor.utils.io.writeFully
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.nio.ByteBuffer
+import java.util.concurrent.atomic.AtomicBoolean
+
+class KtorNetworkServerTest {
+    @Test
+    fun `server echoes bytes using direct buffer`() =
+        runBlocking {
+            val directUsed = AtomicBoolean(false)
+            val pool =
+                object : ObjectPool<ByteBuffer> {
+                    private val delegate = DefaultByteBufferPool
+
+                    override val capacity: Int
+                        get() = delegate.capacity
+
+                    override fun borrow(): ByteBuffer {
+                        val buffer = delegate.borrow()
+                        if (buffer.isDirect) directUsed.set(true)
+                        return buffer
+                    }
+
+                    override fun recycle(instance: ByteBuffer) {
+                        delegate.recycle(instance)
+                    }
+
+                    override fun dispose() {
+                        delegate.dispose()
+                    }
+
+                    override fun close() {
+                        delegate.close()
+                    }
+                }
+
+            val handler =
+                TcpSessionHandler { socket, bufferPool ->
+                    val reader = socket.openReadChannel()
+                    val writer = socket.openWriteChannel(autoFlush = true)
+                    val buffer = bufferPool.borrow()
+                    try {
+                        while (!reader.isClosedForRead) {
+                            buffer.clear()
+                            val read = reader.readAvailable(buffer)
+                            if (read == -1) break
+                            buffer.flip()
+                            writer.writeFully(buffer)
+                        }
+                    } finally {
+                        bufferPool.recycle(buffer)
+                        socket.close()
+                    }
+                }
+
+            val server = KtorNetworkServer(ServerConfig(port = 0), handler, pool)
+            server.start()
+
+            val selector = SelectorManager(Dispatchers.IO)
+            val socket = aSocket(selector).tcp().connect("127.0.0.1", server.port)
+            val writer = socket.openWriteChannel(autoFlush = true)
+            val reader = socket.openReadChannel()
+
+            val message = "hello"
+            val sendBuffer = ByteBuffer.wrap(message.encodeToByteArray())
+            writer.writeFully(sendBuffer)
+            writer.close()
+
+            val received = reader.readRemaining().readBytes()
+            assertEquals(message, received.decodeToString())
+
+            socket.close()
+            selector.close()
+            server.stop()
+
+            assertTrue(directUsed.get())
+        }
+}


### PR DESCRIPTION
## Summary
- wire Ktor network dependencies for the shared network module
- add Ktor-based TCP server that uses a direct ByteBuffer pool
- cover server with an echo test exercising the pool

## Testing
- `./gradlew :shared:network:compileKotlin`
- `./gradlew :shared:network:compileTestKotlin`


------
https://chatgpt.com/codex/tasks/task_e_68b606b8d200832992d513dcaa5e1e9f